### PR TITLE
chore: upgrade version of node-tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mock-fs": "^4.7.0",
     "mockery": "^2.1.0",
     "sinon": "^7.1.1",
-    "tap": "^9.0.3"
+    "tap": "^12.1.0"
   },
   "dependencies": {
     "bluebird": "^3.0.5",

--- a/test/index.js
+++ b/test/index.js
@@ -298,14 +298,16 @@ tap.test('API', function (t) {
 					function (error, pantry) {
 						t.type(error, Error);
 						t.equals(pantry, undefined, 'pantry should be undefined');
-						t.end();
 					})
 					.catch(function (e) {
-						if (e.code !== 'ENOENT') {
+						if (!e.message.match(/Pantry .* does not exist\.$/)) {
 							throw e;
 						}
 					})
-					.finally(restoreMockFS);
+					.finally(function () {
+						restoreMockFS();
+						t.end();
+					});
 			});
 		});
 


### PR DESCRIPTION
With the latest version of node-tap, the `.catch()` in this test was still being executed which caused the error to be both handled by the callback as well as show up as a rethrown error.